### PR TITLE
enableNotification 之后可以被动接收数据

### DIFF
--- a/src/android/BLE.java
+++ b/src/android/BLE.java
@@ -1140,6 +1140,10 @@ public class BLE
 			return false;
 		}
 
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && gatt != null) {
+			gatt.requestMtu(512);
+		}
+
 		return true;
 	}
 

--- a/src/android/BLE.java
+++ b/src/android/BLE.java
@@ -1047,6 +1047,13 @@ public class BLE
 	{
 		final GattHandler gh = mConnectedDevices.get(args.getInt(0));
 
+        if (Build.VERSION.SDK_INT >= 21) {
+            if (!gh.mGatt.requestMtu(512)) {
+                callbackContext.error("requestMtu failed");
+                return;
+            }
+        }
+
 		// Get characteristic.
 		BluetoothGattCharacteristic characteristic = gh.mCharacteristics.get(args.getInt(1));
 
@@ -1138,10 +1145,6 @@ public class BLE
 		if (!success) {
 			callbackContext.error("Could not write config descriptor");
 			return false;
-		}
-
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && gatt != null) {
-			gatt.requestMtu(512);
 		}
 
 		return true;
@@ -1577,6 +1580,12 @@ public class BLE
 		{
 			CallbackContext cc = mNotifications.get(c);
 			keepCallback(cc, c.getValue());
+		}
+
+		@Override
+		public void onMtuChanged(BluetoothGatt gatt, int mtu, int status)
+		{
+			System.out.println("onMtuChanged("+mtu+")"+status);
 		}
 	}
 


### PR DESCRIPTION
enableNotification 之后可以被动接收数据
注：request mtu 紧跟在 gatt.setCharacteristicNotification 之后使用无效果，当时需要调试时断点停一下才有效果，后调整到 gatt.setCharacteristicNotification 方法之前使用。